### PR TITLE
low-end devices support; go modules support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/brotherpowers/ipsubnet
+
+go 1.15

--- a/hostPortion.go
+++ b/hostPortion.go
@@ -9,7 +9,7 @@ func (s *Ip) GetHostPortion() string {
 	return s.hostCalculation("%d", ".")
 }
 
-func (s *Ip) GetHostPortionQuards() []int {
+func (s *Ip) GetHostPortionQuards() []byte {
 	return convertQuardsToInt(strings.Split(s.hostCalculation("%d", "."), "."))
 }
 
@@ -24,10 +24,10 @@ func (s *Ip) GetHostPortionBinary() string {
 func (s *Ip) hostCalculation(format, separator string) string {
 	splits := s.GetIPAddressQuads()
 	networkQuards := []string{}
-	networkQuards = append(networkQuards, fmt.Sprintf(format, splits[0] & ^(s.subnet_mask>>24)))
-	networkQuards = append(networkQuards, fmt.Sprintf(format, splits[1] & ^(s.subnet_mask>>16)))
-	networkQuards = append(networkQuards, fmt.Sprintf(format, splits[2] & ^(s.subnet_mask>>8)))
-	networkQuards = append(networkQuards, fmt.Sprintf(format, splits[3] & ^(s.subnet_mask>>0)))
+	networkQuards = append(networkQuards, fmt.Sprintf(format, splits[0] & ^byte(s.subnet_mask>>24)))
+	networkQuards = append(networkQuards, fmt.Sprintf(format, splits[1] & ^byte(s.subnet_mask>>16)))
+	networkQuards = append(networkQuards, fmt.Sprintf(format, splits[2] & ^byte(s.subnet_mask>>8)))
+	networkQuards = append(networkQuards, fmt.Sprintf(format, splits[3] & ^byte(s.subnet_mask>>0)))
 
 	return strings.Join(networkQuards, separator)
 }

--- a/ip.go
+++ b/ip.go
@@ -4,11 +4,11 @@ import "strconv"
 
 type Ip struct {
 	ip          string
-	networkSize int
-	subnet_mask int
+	networkSize int64
+	subnet_mask int64
 }
 
-func SubnetCalculator(ip string, networkSize int) *Ip {
+func SubnetCalculator(ip string, networkSize int64) *Ip {
 
 	s := &Ip{
 		ip:          ip,
@@ -19,15 +19,15 @@ func SubnetCalculator(ip string, networkSize int) *Ip {
 	return s
 }
 
-func convertQuardsToInt(splits []string) []int {
-	quardsInt := []int{}
+func convertQuardsToInt(splits []string) []byte {
+	quardsInt := []byte{}
 
 	for _, quard := range splits {
 		j, err := strconv.Atoi(quard)
 		if err != nil {
 			panic(err)
 		}
-		quardsInt = append(quardsInt, j)
+		quardsInt = append(quardsInt, byte(j))
 	}
 
 	return quardsInt

--- a/ipPortion.go
+++ b/ipPortion.go
@@ -17,7 +17,7 @@ func (s *Ip) GetIPAddressBinary() string {
 	return s.ipAddressCalculation("%08b", "")
 }
 
-func (s *Ip) GetIPAddressQuads() []int {
+func (s *Ip) GetIPAddressQuads() []byte {
 	splits := strings.Split(s.ip, ".")
 
 	return convertQuardsToInt(splits)

--- a/ip_test.go
+++ b/ip_test.go
@@ -4,27 +4,27 @@ import "testing"
 
 type TestCase struct {
 	ip                     string
-	subnet                 int
-	numberIPAddresses      int
-	numberAddressableHosts int
+	subnet                 int64
+	numberIPAddresses      int64
+	numberAddressableHosts int64
 	ipAddressRange         []string
-	networkSize            int
+	networkSize            int64
 	broadCastAddress       string
-	ipAddressQuards        []int
+	ipAddressQuards        []byte
 	ipAddressHex           string
 	ipAddressBinary        string
 	subnetMask             string
-	subnetMaskQuards       []int
+	subnetMaskQuards       []byte
 	subnetMaskHex          string
 	subnetMaskBinary       string
 
 	networkPortion       string
-	networkPortionQuards []int
+	networkPortionQuards []byte
 	networkPortionHex    string
 	networkPortionBinary string
 
 	hostPortion       string
-	hostPortionQuards []int
+	hostPortionQuards []byte
 	hostPortionHex    string
 	hostPortionBinary string
 }
@@ -38,22 +38,22 @@ func builder() TestCase {
 	test.ipAddressRange = []string{"192.168.112.0", "192.168.113.255"}
 	test.networkSize = 23
 	test.broadCastAddress = "192.168.113.255"
-	test.ipAddressQuards = []int{192, 168, 112, 203}
+	test.ipAddressQuards = []byte{192, 168, 112, 203}
 	test.ipAddressHex = "C0A870CB"
 	test.ipAddressBinary = "11000000101010000111000011001011"
 	// Subnet
 	test.subnetMask = "255.255.254.0"
-	test.subnetMaskQuards = []int{255, 255, 254, 0}
+	test.subnetMaskQuards = []byte{255, 255, 254, 0}
 	test.subnetMaskHex = "FFFFFE00"
 	test.subnetMaskBinary = "11111111111111111111111000000000"
 	// Network Portion
 	test.networkPortion = "192.168.112.0"
-	test.networkPortionQuards = []int{192, 168, 112, 0}
+	test.networkPortionQuards = []byte{192, 168, 112, 0}
 	test.networkPortionHex = "C0A87000"
 	test.networkPortionBinary = "11000000101010000111000000000000"
 	// Network Portion
 	test.hostPortion = "0.0.0.203"
-	test.hostPortionQuards = []int{0, 0, 0, 203}
+	test.hostPortionQuards = []byte{0, 0, 0, 203}
 	test.hostPortionHex = "000000CB"
 	test.hostPortionBinary = "00000000000000000000000011001011"
 	return test

--- a/networkInfo.go
+++ b/networkInfo.go
@@ -5,20 +5,20 @@ import (
 	"strings"
 )
 
-func (s *Ip) GetNumberIPAddresses() int {
+func (s *Ip) GetNumberIPAddresses() int64 {
 	return 2 << uint(31-s.networkSize)
 }
 
-func (s *Ip) GetNumberAddressableHosts() int {
+func (s *Ip) GetNumberAddressableHosts() int64 {
 	if s.networkSize == 32 {
 		return 1
 	} else if s.networkSize == 31 {
 		return 2
 	}
-	return (s.GetNumberIPAddresses() - 2)
+	return s.GetNumberIPAddresses() - 2
 }
 
-func (s *Ip) GetNetworkSize() int {
+func (s *Ip) GetNetworkSize() int64 {
 	return s.networkSize
 }
 
@@ -30,10 +30,10 @@ func (s *Ip) GetBroadcastAddress() string {
 	networkQuads := s.GetNetworkPortionQuards()
 	numberIPAddress := s.GetNumberIPAddresses()
 	networkRangeQuads := []string{}
-	networkRangeQuads = append(networkRangeQuads, fmt.Sprintf("%d", (networkQuads[0]&(s.subnet_mask>>24))+(((numberIPAddress-1)>>24)&0xFF)))
-	networkRangeQuads = append(networkRangeQuads, fmt.Sprintf("%d", (networkQuads[1]&(s.subnet_mask>>16))+(((numberIPAddress-1)>>16)&0xFF)))
-	networkRangeQuads = append(networkRangeQuads, fmt.Sprintf("%d", (networkQuads[2]&(s.subnet_mask>>8))+(((numberIPAddress-1)>>8)&0xFF)))
-	networkRangeQuads = append(networkRangeQuads, fmt.Sprintf("%d", (networkQuads[3]&(s.subnet_mask>>0))+(((numberIPAddress-1)>>0)&0xFF)))
+	networkRangeQuads = append(networkRangeQuads, fmt.Sprintf("%d", (networkQuads[0]&byte(s.subnet_mask>>24))+byte(((numberIPAddress-1)>>24)&0xFF)))
+	networkRangeQuads = append(networkRangeQuads, fmt.Sprintf("%d", (networkQuads[1]&byte(s.subnet_mask>>16))+byte(((numberIPAddress-1)>>16)&0xFF)))
+	networkRangeQuads = append(networkRangeQuads, fmt.Sprintf("%d", (networkQuads[2]&byte(s.subnet_mask>>8))+byte(((numberIPAddress-1)>>8)&0xFF)))
+	networkRangeQuads = append(networkRangeQuads, fmt.Sprintf("%d", (networkQuads[3]&byte(s.subnet_mask>>0))+byte(((numberIPAddress-1)>>0)&0xFF)))
 
 	return strings.Join(networkRangeQuads, ".")
 }

--- a/networkPortion.go
+++ b/networkPortion.go
@@ -9,7 +9,7 @@ func (s *Ip) GetNetworkPortion() string {
 	return s.networkCalculation("%d", ".")
 }
 
-func (s *Ip) GetNetworkPortionQuards() []int {
+func (s *Ip) GetNetworkPortionQuards() []byte {
 	return convertQuardsToInt(strings.Split(s.networkCalculation("%d", "."), "."))
 }
 
@@ -24,10 +24,10 @@ func (s *Ip) GetNetworkPortionBinary() string {
 func (s *Ip) networkCalculation(format, separator string) string {
 	splits := s.GetIPAddressQuads()
 	networkQuards := []string{}
-	networkQuards = append(networkQuards, fmt.Sprintf(format, splits[0]&(s.subnet_mask>>24)))
-	networkQuards = append(networkQuards, fmt.Sprintf(format, splits[1]&(s.subnet_mask>>16)))
-	networkQuards = append(networkQuards, fmt.Sprintf(format, splits[2]&(s.subnet_mask>>8)))
-	networkQuards = append(networkQuards, fmt.Sprintf(format, splits[3]&(s.subnet_mask>>0)))
+	networkQuards = append(networkQuards, fmt.Sprintf(format, splits[0]&byte(s.subnet_mask>>24)))
+	networkQuards = append(networkQuards, fmt.Sprintf(format, splits[1]&byte(s.subnet_mask>>16)))
+	networkQuards = append(networkQuards, fmt.Sprintf(format, splits[2]&byte(s.subnet_mask>>8)))
+	networkQuards = append(networkQuards, fmt.Sprintf(format, splits[3]&byte(s.subnet_mask>>0)))
 
 	return strings.Join(networkQuards, separator)
 }

--- a/subnetPortion.go
+++ b/subnetPortion.go
@@ -9,7 +9,7 @@ func (s *Ip) GetSubnetMask() string {
 	return s.subnetCalculation("%d", ".")
 }
 
-func (s *Ip) GetSubnetMaskQuards() []int {
+func (s *Ip) GetSubnetMaskQuards() []byte {
 	return convertQuardsToInt(strings.Split(s.subnetCalculation("%d", "."), "."))
 }
 


### PR DESCRIPTION
Adds explicit size for integers, from int to int64: this is required in order to support lower end devices (there int size is 32 bits or anyway less than 64 bits); makes use of byte slices instead of int slices to represent quards; adds go module support